### PR TITLE
Forcibly ordered table rows for clarity purposes in frontend state management

### DIFF
--- a/routers/cards.js
+++ b/routers/cards.js
@@ -5,7 +5,7 @@ const router = new Router();
 
 router.get("/", async (req, res, next) => {
   try {
-    const cards = await Card.findAll();
+    const cards = await Card.findAll({ order: [["id", "ASC"]] });
     res.send(cards);
   } catch (error) {
     next(error);

--- a/routers/collections.js
+++ b/routers/collections.js
@@ -22,7 +22,10 @@ router.get("/:id", async (req, res, next) => {
       return res.status(400).send();
     }
 
-    const collection = await Collection.findByPk(id, { include: [Card] });
+    const collection = await Collection.findByPk(id, {
+      include: [Card],
+      order: [["id", "ASC"]],
+    });
 
     if (collection === null) {
       return res.status(404).send();

--- a/routers/sessions.js
+++ b/routers/sessions.js
@@ -2,6 +2,7 @@ const { Router } = require("express");
 const Session = require("../models").session;
 const ScoredCard = require("../models").scoredCard;
 const authMiddleware = require("../auth/middleware");
+const { sequelize } = require("sequelize");
 
 const router = new Router();
 
@@ -11,6 +12,7 @@ router.get("/", authMiddleware, async (req, res, next) => {
     const sessions = await Session.findAll({
       include: [ScoredCard],
       where: { userId: userId },
+      order: [["id", "ASC"]],
     });
 
     res.status(200).send(sessions);


### PR DESCRIPTION
Did wonder why the data was supposedly randomly fetched, according to the Redux DevTools browser extension; issue gone after forcing an order from the backend.

(Side note: the cards are still mapped with the wrong order, but that's because of the logic used to determine buttons on/off switch & dynamic progress bar)