### PR TITLE
Added endpoint to GET user's session stats by collection

### DIFF
--- a/routers/sessions.js
+++ b/routers/sessions.js
@@ -61,4 +61,27 @@ router.patch(
   }
 );
 
+router.get("/stats/:collectionId", authMiddleware, async (req, res, next) => {
+  try {
+    const userId = req.user.dataValues["id"];
+    const { collectionId } = req.params;
+    const sessions = await Session.findAll({
+      include: [ScoredCard],
+      where: {
+        userId: userId,
+        collectionId: collectionId,
+      },
+      order: [["id", "ASC"]],
+    });
+
+    const nonEmptySessions = sessions.filter(
+      (session) => session.scoredCards.length !== 0
+    );
+
+    res.status(200).send(nonEmptySessions);
+  } catch (error) {
+    next(error);
+  }
+});
+
 module.exports = router;


### PR DESCRIPTION
- Only sessions belonging to the logged-in user and to the active collection are sent
- Sessions without `scoredCards` are filtered out
- Sessions do _not_ need to be `finished` to be taken into account